### PR TITLE
Feature/debug

### DIFF
--- a/Neurospace-Team5/BCI/BCIJSONPlaybackService.swift
+++ b/Neurospace-Team5/BCI/BCIJSONPlaybackService.swift
@@ -48,7 +48,9 @@ final class BCIJSONPlaybackService {
 
         timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
             guard let self else { return }
-            self.playNext()
+            Task { @MainActor [weak self] in
+                self?.playNext()
+            }
         }
     }
 

--- a/Neurospace-Team5/Controllers/BubbleGameController.swift
+++ b/Neurospace-Team5/Controllers/BubbleGameController.swift
@@ -303,6 +303,14 @@ final class BubbleGameController {
             return
         }
 
+        // Move arm tip to bubble position so the visual pose updates to point at it
+        let bubblePos = bubbles[idx].position
+        currentArmState.tipPosition = SIMD3<Float>(
+            min(max(bubblePos.x, xLimit.lowerBound), xLimit.upperBound),
+            min(max(bubblePos.y, yLimit.lowerBound), yLimit.upperBound),
+            min(max(bubblePos.z, zLimit.lowerBound), zLimit.upperBound)
+        )
+
         registerBubblePop(at: idx)
         checkSessionFinished()
     }
@@ -491,6 +499,11 @@ final class BubbleGameController {
         // Keep them naturally separated
         let minDistance = config.bubbleRadius * 3.2
 
+        // Arm tip starting positions — bubbles must not spawn within autoPopIfTouching range
+        let rightTipStart = SIMD3<Float>(0.16, 0.02, 0.00)
+        let leftTipStart  = SIMD3<Float>(-0.16, 0.02, 0.00)
+        let safeRadius = max(config.bubbleRadius + 0.028, 0.06) + 0.10
+
         var positions: [SIMD3<Float>] = []
         var tries = 0
 
@@ -510,6 +523,12 @@ final class BubbleGameController {
                 abs(candidate.z) < 0.08
 
             if tooCloseToCenter {
+                continue
+            }
+
+            // Ensure bubble doesn't spawn within immediate pop range of arm starting position
+            if simd_distance(candidate, rightTipStart) < safeRadius ||
+               simd_distance(candidate, leftTipStart) < safeRadius {
                 continue
             }
 

--- a/Neurospace-Team5/Controllers/BubbleGameController.swift
+++ b/Neurospace-Team5/Controllers/BubbleGameController.swift
@@ -19,6 +19,13 @@ final class BubbleGameController {
     var bubbles: [Bubble] = []
     var score: Int = 0
 
+    // Gaze-based targeting — set each frame by ImmersiveView
+    var targetedBubbleID: UUID? = nil
+
+    // Increments on every successful bubble pop — observed by ImmersiveView to
+    // trigger the arm "reach" animation as click feedback.
+    private(set) var popCount: Int = 0
+
     // Stage
     var currentStage: Int = 1
     var targetBubbleColor: String = "Pink"
@@ -117,6 +124,8 @@ final class BubbleGameController {
         targetDirection = .zero
         filteredDirection = .zero
         remainingSeconds = stageConfig.duration
+        targetedBubbleID = nil
+        popCount = 0
 
         leftArmState = ArmState(
             basePosition: [-0.22, -0.14, 0.08],
@@ -152,6 +161,7 @@ final class BubbleGameController {
         filteredDirection = .zero
         sessionState = .ready
         remainingSeconds = stageConfig.duration
+        targetedBubbleID = nil
 
         leftArmState = ArmState(
             basePosition: [-0.22, -0.14, 0.08],
@@ -285,12 +295,17 @@ final class BubbleGameController {
         currentArmState.tipPosition = newTip
 
         if sessionState == .playing {
-            autoPopIfTouching()
             updateBubbleLifecycle(deltaTime: deltaTime)
         }
     }
 
     // MARK: - Tap-to-pop
+
+    /// Pops the bubble currently targeted by the user's gaze (set by ImmersiveView).
+    func popTargetedBubble() {
+        guard sessionState == .playing, let id = targetedBubbleID else { return }
+        popBubble(withID: id)
+    }
 
     func popBubble(withID id: UUID) {
         guard sessionState == .playing else { return }
@@ -455,6 +470,7 @@ final class BubbleGameController {
         hitCount += 1
         attemptCount += 1
         accuracy = Double(hitCount) / Double(attemptCount)
+        popCount += 1
     }
 
     private func updateBubbleLifecycle(deltaTime: Float) {

--- a/Neurospace-Team5/Immersive/ImmersiveView.swift
+++ b/Neurospace-Team5/Immersive/ImmersiveView.swift
@@ -140,7 +140,11 @@ struct ImmersiveView: View {
             else { return }
 
             let controller = appModel.gameController
+            // isReadyStage: controls StartOrb UI — only shown in .ready state
             let isReadyStage = controller.sessionState == .ready
+            // useIdleArm: controls arm pose — idle in .ready and .finished to avoid
+            // the arm pointing at the last-popped bubble during stage transitions
+            let useIdleArm = controller.sessionState == .ready || controller.sessionState == .finished
 
             let activeState = controller.activeArm == .left
                 ? controller.leftArmState
@@ -149,7 +153,7 @@ struct ImmersiveView: View {
             let zoneToShow: BubbleZone
             let variantToShow: PoseVariant
 
-            if isReadyStage {
+            if useIdleArm {
                 zoneToShow = .middleMiddle
                 variantToShow = .right
             } else {
@@ -173,7 +177,7 @@ struct ImmersiveView: View {
                 armsRoot,
                 activeState: activeState,
                 activeArm: controller.activeArm,
-                isReadyStage: isReadyStage
+                isReadyStage: useIdleArm
             )
 
             if isReadyStage {
@@ -523,27 +527,14 @@ struct ImmersiveView: View {
                 translation: SIMD3<Float>(0.0, -0.16, -0.16)
             )
         } else {
-            let armDelta = activeState.tipPosition - activeState.basePosition
-
-            var desired = SIMD3<Float>(0.0, -0.30, -0.30)
-            desired.x += max(-0.14, min(0.14, armDelta.x * 1.6))
-            desired.y += max(-0.12, min(0.14, armDelta.y * 1.4))
-            desired.z += max(-0.10, min(0.10, armDelta.z * 1.1))
-
-            let xSign: Float = activeArm == .left ? -1.0 : 1.0
-            let yaw = max(-0.22, min(0.22, armDelta.x * 1.4 * xSign))
-            let pitch = max(-0.16, min(0.16, -armDelta.y * 1.1))
-            let roll = max(-0.12, min(0.12, armDelta.x * 0.7 * xSign))
-
-            let orientation =
-                simd_quatf(angle: yaw, axis: SIMD3<Float>(0, 1, 0)) *
-                simd_quatf(angle: pitch, axis: SIMD3<Float>(1, 0, 0)) *
-                simd_quatf(angle: roll, axis: SIMD3<Float>(0, 0, 1))
-
+            // Fix armsRoot at a constant position — arm direction is expressed
+            // entirely through USDZ pose selection (stableVisualZone).
+            // Delta-based translation caused the center to shift when tipPosition
+            // jumped (e.g. clicking a left-side bubble with the right arm).
             targetTransform = Transform(
                 scale: SIMD3<Float>(repeating: 1.0),
-                rotation: orientation,
-                translation: desired
+                rotation: simd_quatf(angle: 0.0, axis: SIMD3<Float>(0, 1, 0)),
+                translation: SIMD3<Float>(0.0, -0.30, -0.30)
             )
         }
 

--- a/Neurospace-Team5/Immersive/ImmersiveView.swift
+++ b/Neurospace-Team5/Immersive/ImmersiveView.swift
@@ -6,7 +6,9 @@
 import SwiftUI
 import RealityKit
 import RealityKitContent
+import ARKit
 import simd
+import QuartzCore
 
 private enum BubbleZone: String, CaseIterable {
     case upperLeft
@@ -53,24 +55,51 @@ struct ImmersiveView: View {
 
     @State private var startHoverBeganAt: Date? = nil
     @State private var startTargetHighlighted = false
+    @State private var clickCount: Int = 0       // increments on every tap while playing
+
+    /// Class wrapper so mutations don't trigger SwiftUI re-renders or
+    /// "Modifying state during view update" warnings.
+    private final class BubbleEntityStore {
+        var entities: [UUID: ModelEntity] = [:]
+        var lastSeenClickCount: Int = 0
+        weak var worldAnchor: AnchorEntity?
+        weak var armsAnchor: AnchorEntity?
+        weak var backgroundPlane: Entity?
+        let arSession = ARKitSession()
+        let worldTracking = WorldTrackingProvider()
+        var arSessionStarted = false
+    }
+
+    private let worldAnchorOffset = SIMD3<Float>(0, 1.45, -1.0)
+    @State private var bubbleStore = BubbleEntityStore()
 
     private let startOrbPosition = SIMD3<Float>(0.0, -0.06, 0.02)
     private let startPanelPosition = SIMD3<Float>(0.0, 0.20, 0.02)
 
     var body: some View {
         RealityView { content, attachments in
-            let worldAnchor = AnchorEntity(world: SIMD3<Float>(0, 1.45, -1.0))
+            let worldAnchor = AnchorEntity(world: worldAnchorOffset)
             worldAnchor.name = "WorldAnchor"
 
             let root = Entity()
             root.name = "Root"
             root.position = .zero
 
-            if appModel.gameController.sessionState != .ready {
-                for bubble in appModel.gameController.bubbles where !bubble.isGone {
-                    root.addChild(makeBubbleEntity(for: bubble))
-                }
-            }
+            // Bubbles are managed via bubbleStore in syncBubbles; none are needed here.
+
+            // Large invisible background entity that catches taps in empty space.
+            // Placed behind the bubble interaction zone so bubble entities take
+            // priority when directly targeted; misses fall through to this plane.
+            let bgEntity = Entity()
+            bgEntity.name = "BackgroundPlane"
+            bgEntity.position = SIMD3<Float>(0, 0.10, -0.60)   // behind bubble z range
+            bgEntity.components.set(CollisionComponent(
+                shapes: [.generateBox(width: 6.0, height: 4.0, depth: 0.05)]
+            ))
+            bgEntity.components.set(InputTargetComponent())
+            bgEntity.isEnabled = false   // enabled only while session is playing
+            root.addChild(bgEntity)
+            bubbleStore.backgroundPlane = bgEntity
 
             let startOrb = makeStartOrbEntity(
                 name: "StartOrb",
@@ -94,9 +123,11 @@ struct ImmersiveView: View {
 
             worldAnchor.addChild(root)
             content.add(worldAnchor)
+            bubbleStore.worldAnchor = worldAnchor
 
             let armsAnchor = AnchorEntity(.head, trackingMode: .continuous)
             armsAnchor.name = "ArmsAnchor"
+            bubbleStore.armsAnchor = armsAnchor
 
             let armsRoot = Entity()
             armsRoot.name = "ArmsRoot"
@@ -125,6 +156,7 @@ struct ImmersiveView: View {
                 named: poseName(for: .middleMiddle, variant: .right)
             ) {
                 idlePose.isEnabled = true
+                playAnimationIfAvailable(on: idlePose)
             }
 
             armsAnchor.addChild(armsRoot)
@@ -153,25 +185,30 @@ struct ImmersiveView: View {
             let zoneToShow: BubbleZone
             let variantToShow: PoseVariant
 
-            if useIdleArm {
-                zoneToShow = .middleMiddle
-                variantToShow = .right
-            } else {
-                zoneToShow = stableVisualZone(
-                    for: activeState,
-                    currentZone: currentVisibleZone(
-                        in: armsRoot,
-                        variant: controller.activeArm == .left ? .left : .right
-                    )
-                )
-                variantToShow = controller.activeArm == .left ? .left : .right
-            }
+            // Arm always points center (middleMiddle) — direction is handled by gaze targeting
+            zoneToShow = .middleMiddle
+            variantToShow = useIdleArm ? .right : (controller.activeArm == .left ? .left : .right)
 
             updateArmPoseDisplay(
                 in: armsRoot,
                 zone: zoneToShow,
                 variant: variantToShow
             )
+
+            // Re-trigger arm animation on every tap while playing.
+            // Mutation goes through bubbleStore (class), not @State, to avoid
+            // "Modifying state during view update" warnings.
+            // playAnimationIfAvailable is deferred via Task to avoid calling
+            // playAnimation during RealityKit's update cycle (bind point warning).
+            if clickCount != bubbleStore.lastSeenClickCount {
+                bubbleStore.lastSeenClickCount = clickCount
+                let tapPoseName = poseName(for: zoneToShow, variant: variantToShow)
+                if let pose = armsRoot.findEntity(named: tapPoseName) {
+                    Task { @MainActor in
+                        playAnimationIfAvailable(on: pose)
+                    }
+                }
+            }
 
             updateArmsRootTransform(
                 armsRoot,
@@ -180,10 +217,22 @@ struct ImmersiveView: View {
                 isReadyStage: useIdleArm
             )
 
+            // Gaze-based targeting using coordinate-space conversion.
+            // bubble.position is in worldAnchor-local space.
+            // armsAnchor.convert(position:from:) maps it to head-local space without
+            // needing scene entity lookups (which are unreliable in the update closure).
+            // In head-local space, screen center = (0, 0, -depth); smallest lateral
+            // angle = most centered bubble.
+            // Compute gaze targeting, then apply result via Task to avoid mutating
+            // @Observable state during the view update cycle.
+            // Gaze targeting runs from the .task loop via updateGazeAndFOV(),
+            // because the update closure does not re-run on head motion alone.
+
             if isReadyStage {
                 removeAllBubbleEntities(from: root)
             } else {
-                syncBubbles(in: root, with: controller.bubbles)
+                syncBubbles(in: root, with: controller.bubbles,
+                            targetedID: controller.targetedBubbleID)
             }
 
             let showStartTarget = isReadyStage
@@ -222,17 +271,32 @@ struct ImmersiveView: View {
                 .onEnded { value in
                     let name = value.entity.name
 
+                    // Ready state: only StartOrb starts the session
                     if name == "StartOrb", appModel.gameController.sessionState == .ready {
                         triggerSessionStart()
                         return
                     }
 
+                    guard appModel.gameController.sessionState == .playing else { return }
+
+                    // Empty-space tap: background entity caught the hit → arm animation only
+                    if name == "BackgroundPlane" {
+                        clickCount += 1
+                        return
+                    }
+
                     guard name.hasPrefix("Bubble_") else { return }
 
-                    let uuidString = String(name.dropFirst("Bubble_".count))
-                    guard let id = UUID(uuidString: uuidString) else { return }
+                    // Any bubble tap triggers arm animation
+                    clickCount += 1
 
-                    appModel.gameController.popBubble(withID: id)
+                    // Only pop if the tapped bubble is the currently targeted one.
+                    // Tapping a non-targeted bubble triggers arm animation but no pop.
+                    let uuidString = String(name.dropFirst("Bubble_".count))
+                    guard let tappedID = UUID(uuidString: uuidString),
+                          tappedID == appModel.gameController.targetedBubbleID else { return }
+
+                    appModel.gameController.popTargetedBubble()
                 }
         )
         .onChange(of: appModel.gameController.sessionState) { _, newState in
@@ -256,9 +320,18 @@ struct ImmersiveView: View {
             }
         }
         .task { @MainActor in
+            if !bubbleStore.arSessionStarted {
+                bubbleStore.arSessionStarted = true
+                do {
+                    try await bubbleStore.arSession.run([bubbleStore.worldTracking])
+                } catch {
+                    print("ARKit session failed: \(error)")
+                }
+            }
             while !Task.isCancelled {
                 appModel.gameController.update(deltaTime: 1.0 / 60.0)
                 updatePreSessionStartInteraction()
+                updateGazeAndFOV()
 
                 do {
                     try await Task.sleep(for: .seconds(1.0 / 60.0))
@@ -276,6 +349,8 @@ struct ImmersiveView: View {
                 appModel.gameController.resetGame()
                 startHoverBeganAt = nil
                 startTargetHighlighted = false
+                clickCount = 0
+                bubbleStore.lastSeenClickCount = 0
 
                 dismissWindow(id: appModel.congratsWindowID)
                 dismissWindow(id: appModel.missionFailedWindowID)
@@ -506,6 +581,8 @@ struct ImmersiveView: View {
             child.isEnabled = child.name == targetName
         }
 
+        // Play (or restart looping) animation whenever the active pose changes.
+        // Also plays on first call when currentlyVisibleName is nil (fresh scene).
         if currentlyVisibleName != targetName,
            let pose = armsRoot.findEntity(named: targetName) {
             playAnimationIfAvailable(on: pose)
@@ -607,6 +684,53 @@ struct ImmersiveView: View {
     }
 
     @MainActor
+    private func updateGazeAndFOV() {
+        let controller = appModel.gameController
+        let playingNow = controller.sessionState == .playing
+
+        // Background plane catches empty-space taps for arm animation, but
+        // must be disabled outside of .playing so SwiftUI windows (Congrats /
+        // MissionFailed) are not occluded and can receive taps.
+        if let plane = bubbleStore.backgroundPlane, plane.isEnabled != playingNow {
+            plane.isEnabled = playingNow
+        }
+
+        guard bubbleStore.worldTracking.state == .running,
+              let deviceAnchor = bubbleStore.worldTracking.queryDeviceAnchor(
+                atTimestamp: CACurrentMediaTime()
+              )
+        else { return }
+
+        let headFromWorld = simd_inverse(deviceAnchor.originFromAnchorTransform)
+        let centerConeRadians: Float = 15.0 * .pi / 180.0
+
+        var bestAngle: Float = .greatestFiniteMagnitude
+        var bestID: UUID? = nil
+
+        for bubble in controller.bubbles where !bubble.isGone {
+            let bubbleWorld = bubble.position + worldAnchorOffset
+            let bubbleWorld4 = SIMD4<Float>(bubbleWorld.x, bubbleWorld.y, bubbleWorld.z, 1)
+            let headLocal4 = headFromWorld * bubbleWorld4
+            let p = SIMD3<Float>(headLocal4.x, headLocal4.y, headLocal4.z)
+
+            // Forward is -z in head-local space.
+            guard p.z < 0 else { continue }
+
+            let lateral = (p.x * p.x + p.y * p.y).squareRoot()
+            let angle = atan2(lateral, abs(p.z))
+
+            if playingNow && angle < bestAngle && angle <= centerConeRadians {
+                bestAngle = angle
+                bestID = bubble.id
+            }
+        }
+
+        if controller.targetedBubbleID != bestID {
+            controller.targetedBubbleID = bestID
+        }
+    }
+
+    @MainActor
     private func triggerSessionStart() {
         guard appModel.gameController.sessionState == .ready else { return }
         startHoverBeganAt = nil
@@ -614,56 +738,80 @@ struct ImmersiveView: View {
         appModel.gameController.startSession()
     }
 
-    private func makeBubbleEntity(for bubble: Bubble) -> ModelEntity {
+    private func makeBubbleEntity(for bubble: Bubble, isTargeted: Bool = false) -> ModelEntity {
         let radius = appModel.gameController.stageConfig.bubbleRadius
 
         let entity = ModelEntity(
             mesh: .generateSphere(radius: radius),
-            materials: [makeBubbleMaterial(color: bubble.type.uiColor)]
+            materials: [makeBubbleMaterial(color: bubble.type.uiColor, isTargeted: isTargeted)]
         )
 
         entity.name = "Bubble_\(bubble.id.uuidString)"
         entity.position = bubble.position
+        entity.scale = isTargeted ? SIMD3<Float>(repeating: 1.3) : SIMD3<Float>(repeating: 1.0)
         entity.components.set(CollisionComponent(shapes: [.generateSphere(radius: radius)]))
         entity.components.set(InputTargetComponent())
 
         return entity
     }
 
-    private func makeBubbleMaterial(color: UIColor) -> PhysicallyBasedMaterial {
+    private func makeBubbleMaterial(color: UIColor, isTargeted: Bool = false) -> PhysicallyBasedMaterial {
         var material = PhysicallyBasedMaterial()
-        material.baseColor = PhysicallyBasedMaterial.BaseColor(tint: color.withAlphaComponent(0.25))
-        material.roughness = PhysicallyBasedMaterial.Roughness(floatLiteral: 0.0)
-        material.metallic = PhysicallyBasedMaterial.Metallic(floatLiteral: 0.0)
-        material.blending = .transparent(opacity: .init(floatLiteral: 0.25))
-        material.clearcoat = PhysicallyBasedMaterial.Clearcoat(floatLiteral: 1.0)
-        material.clearcoatRoughness = PhysicallyBasedMaterial.ClearcoatRoughness(floatLiteral: 0.0)
+
+        if isTargeted {
+            // Targeted: solid bright white-tinted version of the bubble color + strong glow
+            material.baseColor = PhysicallyBasedMaterial.BaseColor(tint: UIColor.white)
+            material.roughness = PhysicallyBasedMaterial.Roughness(floatLiteral: 0.0)
+            material.metallic = PhysicallyBasedMaterial.Metallic(floatLiteral: 0.0)
+            material.blending = .transparent(opacity: .init(floatLiteral: 0.92))
+            material.clearcoat = PhysicallyBasedMaterial.Clearcoat(floatLiteral: 1.0)
+            material.clearcoatRoughness = PhysicallyBasedMaterial.ClearcoatRoughness(floatLiteral: 0.0)
+            material.emissiveColor = PhysicallyBasedMaterial.EmissiveColor(color: color)
+            material.emissiveIntensity = 3.0
+        } else {
+            // Normal: translucent with bubble's own color
+            material.baseColor = PhysicallyBasedMaterial.BaseColor(tint: color.withAlphaComponent(0.25))
+            material.roughness = PhysicallyBasedMaterial.Roughness(floatLiteral: 0.0)
+            material.metallic = PhysicallyBasedMaterial.Metallic(floatLiteral: 0.0)
+            material.blending = .transparent(opacity: .init(floatLiteral: 0.25))
+            material.clearcoat = PhysicallyBasedMaterial.Clearcoat(floatLiteral: 1.0)
+            material.clearcoatRoughness = PhysicallyBasedMaterial.ClearcoatRoughness(floatLiteral: 0.0)
+        }
+
         return material
     }
 
-    private func syncBubbles(in root: Entity, with bubbles: [Bubble]) {
-        let validNames = Set(bubbles.filter { !$0.isGone }.map { "Bubble_\($0.id.uuidString)" })
+    private func syncBubbles(in root: Entity, with bubbles: [Bubble], targetedID: UUID?) {
+        let activeIDs = Set(bubbles.filter { !$0.isGone }.map { $0.id })
 
-        let toRemove = root.children.filter {
-            $0.name.hasPrefix("Bubble_") && !validNames.contains($0.name)
+        // Remove entities whose bubbles are gone (popped / expired)
+        let goneIDs = bubbleStore.entities.keys.filter { !activeIDs.contains($0) }
+        for id in goneIDs {
+            bubbleStore.entities[id]?.removeFromParent()
+            bubbleStore.entities.removeValue(forKey: id)
         }
-        toRemove.forEach { $0.removeFromParent() }
 
+        // Add or update active bubbles using stored references — bypasses the
+        // RealityView content API limitation where root.children only reflects
+        // entities from the make closure, not those added in prior update calls.
         for bubble in bubbles where !bubble.isGone {
-            let name = "Bubble_\(bubble.id.uuidString)"
+            let isTargeted = bubble.id == targetedID
 
-            if let existing = root.findEntity(named: name) as? ModelEntity {
-                existing.position = bubble.position
-                existing.model?.materials = [makeBubbleMaterial(color: bubble.type.uiColor)]
+            if let entity = bubbleStore.entities[bubble.id] {
+                entity.position = bubble.position
+                entity.model?.materials = [makeBubbleMaterial(color: bubble.type.uiColor, isTargeted: isTargeted)]
+                entity.scale = isTargeted ? SIMD3<Float>(repeating: 1.3) : SIMD3<Float>(repeating: 1.0)
             } else {
-                root.addChild(makeBubbleEntity(for: bubble))
+                let entity = makeBubbleEntity(for: bubble, isTargeted: isTargeted)
+                root.addChild(entity)
+                bubbleStore.entities[bubble.id] = entity
             }
         }
     }
 
     private func removeAllBubbleEntities(from root: Entity) {
-        let bubbles = root.children.filter { $0.name.hasPrefix("Bubble_") }
-        bubbles.forEach { $0.removeFromParent() }
+        bubbleStore.entities.values.forEach { $0.removeFromParent() }
+        bubbleStore.entities.removeAll()
     }
 
     private func makeStartOrbEntity(name: String, position: SIMD3<Float>, highlighted: Bool) -> ModelEntity {

--- a/Neurospace-Team5/Immersive/ImmersiveView.swift
+++ b/Neurospace-Team5/Immersive/ImmersiveView.swift
@@ -176,8 +176,6 @@ struct ImmersiveView: View {
                 isReadyStage: isReadyStage
             )
 
-            popBubblesTouchedByHands(controller: controller)
-
             if isReadyStage {
                 removeAllBubbleEntities(from: root)
             } else {
@@ -557,26 +555,6 @@ struct ImmersiveView: View {
             duration: duration,
             timingFunction: .easeInOut
         )
-    }
-
-    private func popBubblesTouchedByHands(controller: BubbleGameController) {
-        guard controller.sessionState != .ready,
-              controller.sessionState != .finished else { return }
-
-        let leftTip = controller.leftArmState.tipPosition
-        let rightTip = controller.rightArmState.tipPosition
-
-        let bubbleRadius = controller.stageConfig.bubbleRadius
-        let touchRadius = max(0.045, bubbleRadius + 0.020)
-
-        for bubble in controller.bubbles where !bubble.isGone && !bubble.isPopped {
-            let leftTouch = simd_distance(leftTip, bubble.position) <= touchRadius
-            let rightTouch = simd_distance(rightTip, bubble.position) <= touchRadius
-
-            if leftTouch || rightTouch {
-                controller.popBubble(withID: bubble.id)
-            }
-        }
     }
 
     private func playAnimationIfAvailable(on entity: Entity) {

--- a/Neurospace-Team5/UI/GameView.swift
+++ b/Neurospace-Team5/UI/GameView.swift
@@ -43,20 +43,22 @@ struct CongratsView: View {
 
             Button(appModel.gameController.isOnFinalStage ? "Go to Main" : "Next Stage") {
                 Task { @MainActor in
-                    dismissWindow(id: appModel.congratsWindowID)
-                    dismissWindow(id: appModel.missionFailedWindowID)
-
                     if appModel.gameController.canAdvanceStage {
                         appModel.gameController.advanceStage()
+                        print("[Congrats] advanced to stage \(appModel.gameController.currentStage)")
 
                         if appModel.immersiveSpaceState == .open {
                             appModel.gameController.startSession()
+                            dismissWindow(id: appModel.congratsWindowID)
+                            dismissWindow(id: appModel.missionFailedWindowID)
                         } else {
                             appModel.immersiveSpaceState = .inTransition
                             switch await openImmersiveSpace(id: appModel.immersiveSpaceID) {
                             case .opened:
                                 appModel.immersiveSpaceState = .open
                                 appModel.gameController.startSession()
+                                dismissWindow(id: appModel.congratsWindowID)
+                                dismissWindow(id: appModel.missionFailedWindowID)
 
                             case .userCancelled, .error:
                                 fallthrough
@@ -75,6 +77,8 @@ struct CongratsView: View {
                         }
 
                         openWindow(id: appModel.mainWindowID)
+                        dismissWindow(id: appModel.congratsWindowID)
+                        dismissWindow(id: appModel.missionFailedWindowID)
                     }
                 }
             }
@@ -88,13 +92,6 @@ struct CongratsView: View {
         .onChange(of: appModel.shouldEndSession) { _, shouldEnd in
             guard shouldEnd else { return }
             dismissWindow(id: appModel.congratsWindowID)
-        }
-
-        // Also make sure this window disappears if the game is no longer in finished state
-        .onChange(of: appModel.gameController.sessionState) { _, newState in
-            if newState != .finished {
-                dismissWindow(id: appModel.congratsWindowID)
-            }
         }
     }
 }


### PR DESCRIPTION
# Retrospective: Gaze-Based Bubble Targeting

## Goal

Add a gaze-driven targeting system so that only the bubble in the center of
the user's view can be popped, plus a console-log pipeline to verify which
bubbles are currently inside the user's field of view when the head moves.

## What I Built

1. **Center-of-view targeting.** Each frame, the program compute every active bubble's
   position in head-local space and pick the one with the smallest angular
   distance from the gaze axis, within a 15° cone. The winning bubble is
   stored in `BubbleGameController.targetedBubbleID`, and the existing tap
   handler only pops the bubble that matches this ID.
2. **FOV logging (dev-time).** A wider 50° cone was used to decide whether a
   bubble was "in view"; I logged entries/exits from this set to
   confirm the detection responded to head motion. Once the feature was
   verified, the debug prints were removed.
3. **Background plane gating.** The invisible 6×4m `BackgroundPlane` that
   captures empty-space taps (to trigger the arm animation) is now enabled
   only while the session is `.playing`. Outside of that state it is disabled
   so the Congrats / MissionFailed windows can receive taps.
4. **Next Stage handler cleanup.** The button now runs state mutations and
   `startSession()` first, and only calls `dismissWindow` at the very end, so
   environment actions don't run from a destroyed view context.

## Struggles

### 1. `AnchorEntity(.head).convert(...)` returned stale values

The first implementation used `armsAnchor.convert(position: bubble.position, from: worldAnchor)`
inside the `RealityView` update closure, then measured the lateral angle from
the z-axis. Logically this should have given us head-local bubble positions,
but rotating the head produced no change in the console output.

After logging the anchor's own world transform
(`armsAnchor.transformMatrix(relativeTo: nil)`), I saw
`armsAnchorWorld=(0, 0, 0)` on every frame. That was the key discovery:
**on visionOS, `AnchorEntity(.head)` does not surface the head pose through
its own transform.** The framework applies head tracking at render time for
visual children, but the scene-graph transform stays at identity, so
`convert(position:from:)` has nothing rotational to apply.

### 2. `RealityView`'s update closure does not run every frame

Before the anchor issue, I had already moved the FOV logic into the
update closure and still saw nothing. A `tick=1` / `tick=61` / ... heartbeat
showed that the closure only re-ran on observable state changes (session
state, bubble array, etc.), not on head motion. So even with correct math,
the logic wouldn't have fired as the user looked around.

The fix was to run gaze targeting from the existing 60Hz `.task` loop inside
`ImmersiveView`. I cached weak references to the two anchors in a
`BubbleEntityStore` so the async task could reach them without going through
`content.entities` lookups.

### 3. Switching to ARKit `WorldTrackingProvider`

With the two problems combined — no per-frame updates and no head transform
on the anchor — I migrated head-pose sourcing to `ARKitSession` +
`WorldTrackingProvider`. Each frame the program call
`worldTracking.queryDeviceAnchor(atTimestamp: CACurrentMediaTime())` to get a
fresh device pose, invert `originFromAnchorTransform` to obtain a
world-to-head matrix, and multiply it against each bubble's world position
(bubble's local-space position plus the fixed `worldAnchorOffset`). That
finally produced head-local coordinates that changed as the user rotated
their head, and the 15°/50° cone checks started working immediately.

### 4. Next Stage button was unresponsive

Once gaze targeting worked, I hit a different problem: after completing
stage 1 the Congrats window appeared but clicking "Next Stage" did nothing —
not even the button's action closure fired.

Diagnostic prints confirmed:

- `[Finish] opening congrats window` ✅
- `[CongratsView] onAppear stage=1` ✅
- `[Congrats] Next Stage Button fired` ❌ (never printed)

A hypothesis about dismiss-order destroying the view context turned out to
be wrong. The real culprit was the `BackgroundPlane`: a 6×4 m invisible
entity with a `CollisionComponent` and `InputTargetComponent`, placed inside
the immersive space to catch empty-space taps for the arm animation.

Because `InputTargetComponent` surfaces in an immersive space can absorb
gaze-based input, the plane was stealing taps from the SwiftUI window — the
window rendered, the button drew its hover state, but the tap never reached
the `Button` action. Disabling the plane outside of `.playing` fixed it
without losing the arm-animation-on-empty-space feature.

## Lessons Learned

- **Anchor transforms are not always authoritative on visionOS.** For
  anything that needs the real-time head pose (gaze targeting, look-at
  logic, audio cues), use `ARKitSession` + `WorldTrackingProvider`
  explicitly. Don't rely on `AnchorEntity(.head)`'s scene-graph transform.
- **`RealityView`'s update closure is state-driven, not frame-driven.** Any
  logic that must react to continuous sensor input (head pose, hand
  tracking) belongs in a `.task` loop (or a RealityKit `System`), not in
  `update:`.
- **Invisible `InputTargetComponent` surfaces can block SwiftUI windows.**
  If a large collision plane exists for gameplay reasons, gate its
  `isEnabled` on session state so it doesn't interfere with modal UI.
- **When a SwiftUI button action never fires, diagnose the input path, not
  the handler.** Adding an `onTapGesture`-backed test element next to the
  `Button` quickly distinguished "button is broken" from "whole window is
  not receiving input."
