### PR TITLE
Remember BCI host/port and auto-connect on launch

### DIFF
--- a/NeuroSpace/UI/BCIBridgeDemoView.swift
+++ b/NeuroSpace/UI/BCIBridgeDemoView.swift
@@ -2,8 +2,17 @@ import SwiftUI
 
 struct BCIBridgeDemoView: View {
     @State private var client = BCIWebSocketClient()
-    @State private var host: String = Bundle.main.object(forInfoDictionaryKey: "BCI_DEFAULT_HOST") as? String ?? "192.168.1.10"
-    @State private var port: String = Bundle.main.object(forInfoDictionaryKey: "BCI_DEFAULT_PORT") as? String ?? "8765"
+
+    private static let defaultHost: String =
+        Bundle.main.object(forInfoDictionaryKey: "BCI_DEFAULT_HOST") as? String
+        ?? "192.168.1.10"
+    private static let defaultPort: String =
+        Bundle.main.object(forInfoDictionaryKey: "BCI_DEFAULT_PORT") as? String
+        ?? "8765"
+
+    @AppStorage("bci.host") private var host: String = Self.defaultHost
+    @AppStorage("bci.port") private var port: String = Self.defaultPort
+    @AppStorage("bci.autoConnect") private var autoConnect: Bool = true
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -23,6 +32,10 @@ struct BCIBridgeDemoView: View {
                 Button("Connect") {
                     client.connect(host: host, port: Int(port) ?? 8765)
                 }
+                Button("Use Default") {
+                    host = Self.defaultHost
+                    port = Self.defaultPort
+                }
                 Button("Ping") {
                     client.sendPing()
                 }
@@ -38,6 +51,9 @@ struct BCIBridgeDemoView: View {
             Text("Last intent: \(client.lastIntent)")
             Text("Confidence: \(client.lastConfidence.formatted(.number.precision(.fractionLength(2))))")
 
+            Toggle("Auto-connect on launch", isOn: $autoConnect)
+                .toggleStyle(.switch)
+
             Divider()
 
             ScrollView {
@@ -52,6 +68,10 @@ struct BCIBridgeDemoView: View {
         }
         .padding(24)
         .frame(minWidth: 700, minHeight: 500)
+        .onAppear {
+            guard autoConnect else { return }
+            client.connect(host: host, port: Int(port) ?? 8765)
+        }
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Persists the BCI WebSocket host + port using `@AppStorage`, so users don’t need to retype the IP every launch.
- Adds an **Auto-connect on launch** toggle.
- Adds a **Use Default** button to quickly reset back to `BCI_DEFAULT_HOST` / `BCI_DEFAULT_PORT`.

### UX impact
- Typical flow becomes: enter host once → next launches are one-tap (or fully automatic).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb12f9ea-bc54-4f6c-aa65-24767fbe8493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb12f9ea-bc54-4f6c-aa65-24767fbe8493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

