### PR TITLE
Remove bilateral arm mode and related code paths

### DIFF
--- a/NeuroSpace/Controllers/BubbleGameController.swift
+++ b/NeuroSpace/Controllers/BubbleGameController.swift
@@ -273,11 +273,6 @@ final class BubbleGameController {
             return
         }
 
-        if !target.canBePopped(by: activeArm) {
-            stopMotion()
-            return
-        }
-
         let tip = currentArmState.tipPosition
         let popRadius = max(stageConfig.bubbleRadius + 0.055, popThreshold + 0.03)
 
@@ -442,10 +437,6 @@ final class BubbleGameController {
         guard let idx = bubbles.firstIndex(where: { $0.id == id }),
               !bubbles[idx].isGone else { return }
 
-        if !bubbles[idx].canBePopped(by: activeArm) {
-            return
-        }
-
         let bubblePos = bubbles[idx].position
         currentArmState.tipPosition = SIMD3<Float>(
             min(max(bubblePos.x, xLimit.lowerBound), xLimit.upperBound),
@@ -486,9 +477,7 @@ final class BubbleGameController {
         guard let bubble = eyeTargetedBubble() else {
             return "None"
         }
-
-        let armName = bubble.assignedArm?.rawValue.capitalized ?? "Any"
-        return "\(armName) \(format(bubble.position))"
+        return "\(bubble.type.displayName) \(format(bubble.position))"
     }
 
     private func format(_ v: SIMD3<Float>) -> String {
@@ -513,7 +502,6 @@ final class BubbleGameController {
         var minDist: Float = .greatestFiniteMagnitude
 
         for bubble in bubbles where !bubble.isGone {
-            guard bubble.canBePopped(by: arm) else { continue }
             minDist = min(minDist, simd_distance(bubble.position, tip))
         }
 
@@ -525,8 +513,6 @@ final class BubbleGameController {
         var minDist: Float = .greatestFiniteMagnitude
 
         for bubble in bubbles where !bubble.isGone {
-            guard bubble.canBePopped(by: activeArm) else { continue }
-
             let d = simd_distance(bubble.position, currentArmState.tipPosition)
             if d < minDist {
                 minDist = d
@@ -554,8 +540,6 @@ final class BubbleGameController {
         var bestScore: Float = -.greatestFiniteMagnitude
 
         for bubble in bubbles where !bubble.isGone {
-            guard bubble.canBePopped(by: activeArm) else { continue }
-
             let toBubble = bubble.position - tip
             let distance = simd_length(toBubble)
 
@@ -724,19 +708,7 @@ final class BubbleGameController {
         }
 
         return positions.map { position in
-            let assignedArm: ActiveArm?
-            let type: BubbleType
-
-            switch config.armMode {
-            case .bilateral:
-                let arm: ActiveArm = position.x < 0 ? .left : .right
-                assignedArm = arm
-                type = arm == .left ? .blue : .red
-            case .singleActive:
-                assignedArm = nil
-                type = BubbleType.randomWeighted()
-            }
-
+            let type: BubbleType = BubbleType.randomWeighted()
             let speed = Float.random(in: config.bubbleSpeed)
 
             let rawDir = SIMD3<Float>(
@@ -752,7 +724,6 @@ final class BubbleGameController {
             return Bubble(
                 position: position,
                 type: type,
-                assignedArm: assignedArm,
                 velocity: velocity,
                 lifetime: config.bubbleLifetime
             )

--- a/NeuroSpace/Models/Bubble.swift
+++ b/NeuroSpace/Models/Bubble.swift
@@ -51,7 +51,6 @@ struct Bubble: Identifiable, Equatable {
     var type: BubbleType
 
     // Stage-aware fields
-    var assignedArm: ActiveArm?    // nil = any arm; set in bilateral stages (4 & 5)
     var velocity: SIMD3<Float>     // non-zero in dynamic stages (5)
     var spawnTime: Date            // used for lifetime tracking
     var lifetime: Double?          // nil = lives until explicitly popped
@@ -61,7 +60,6 @@ struct Bubble: Identifiable, Equatable {
         position: SIMD3<Float>,
         isPopped: Bool = false,
         type: BubbleType = .red,
-        assignedArm: ActiveArm? = nil,
         velocity: SIMD3<Float> = .zero,
         spawnTime: Date = Date(),
         lifetime: Double? = nil
@@ -70,7 +68,6 @@ struct Bubble: Identifiable, Equatable {
         self.position = position
         self.isPopped = isPopped
         self.type = type
-        self.assignedArm = assignedArm
         self.velocity = velocity
         self.spawnTime = spawnTime
         self.lifetime = lifetime
@@ -85,20 +82,11 @@ struct Bubble: Identifiable, Equatable {
     /// True when the bubble should no longer be rendered or interacted with.
     var isGone: Bool { isPopped || isExpired }
 
-    /// Whether the given arm is allowed to pop this bubble.
-    /// Bubbles with `assignedArm == nil` accept any arm (single-active stages).
-    /// Bilateral stages set `assignedArm` to enforce arm-specific pops.
-    func canBePopped(by arm: ActiveArm) -> Bool {
-        guard let assigned = assignedArm else { return true }
-        return assigned == arm
-    }
-
     static func == (lhs: Bubble, rhs: Bubble) -> Bool {
         lhs.id == rhs.id &&
         lhs.position == rhs.position &&
         lhs.isPopped == rhs.isPopped &&
         lhs.type == rhs.type &&
-        lhs.assignedArm == rhs.assignedArm &&
         lhs.velocity == rhs.velocity
     }
 }

--- a/NeuroSpace/Models/StageConfig.swift
+++ b/NeuroSpace/Models/StageConfig.swift
@@ -20,13 +20,6 @@ struct StageConfig {
         static let xyz: AxisSet = [.x, .y, .z]
     }
 
-    // MARK: - Arm mode
-
-    enum ArmMode: Equatable {
-        case singleActive   // whichever arm is currently selected by the player
-        case bilateral      // each bubble is assigned to a specific arm
-    }
-
     // MARK: - Unlock criteria
 
     struct UnlockCriteria {
@@ -43,7 +36,6 @@ struct StageConfig {
     let bubbleCount:     Int
     let bubbleRadius:    Float
     let allowedAxes:     AxisSet
-    let armMode:         ArmMode
     let bubbleSpeed:     ClosedRange<Float>    // 0...0 for static bubbles
     let bubbleLifetime:  Double?               // nil = lives until explicitly popped
     let respawnsEnabled: Bool                  // continuously respawn after all gone
@@ -51,8 +43,6 @@ struct StageConfig {
     let unlockCriteria:  UnlockCriteria
 
     // MARK: - Helpers
-
-    var isBilateral: Bool { armMode == .bilateral }
 
     /// Returns whether a BCI intent is permitted in this stage.
     func isIntentAllowed(_ intent: BCIIntent) -> Bool {
@@ -82,7 +72,6 @@ extension StageConfig {
             bubbleCount: 3,
             bubbleRadius: 0.12,
             allowedAxes: .x,
-            armMode: .singleActive,
             bubbleSpeed: 0...0,
             bubbleLifetime: nil,
             respawnsEnabled: false,
@@ -100,7 +89,6 @@ extension StageConfig {
             bubbleCount: 6,
             bubbleRadius: 0.09,
             allowedAxes: .xy,
-            armMode: .singleActive,
             bubbleSpeed: 0...0,
             bubbleLifetime: nil,
             respawnsEnabled: false,
@@ -118,25 +106,23 @@ extension StageConfig {
             bubbleCount: 8,
             bubbleRadius: 0.06,
             allowedAxes: .xyz,
-            armMode: .singleActive,
             bubbleSpeed: 0...0,
             bubbleLifetime: nil,
             respawnsEnabled: false,
             unlockCriteria: UnlockCriteria(minimumAccuracy: 0.75, requiredPops: 6)
         ),
 
-        // ── Stage 4 · Bilateral Coordination ─────────────────────────────────
-        // Each bubble is colour-coded to a specific arm.
-        // Trains rapid hemispheric switching — the neural basis of bimanual ADL.
+        // ── Stage 4 · Precision Control ──────────────────────────────────────
+        // Higher bubble density in full 3-D space — pushes spatial accuracy
+        // and sustained motor-imagery focus.
         StageConfig(
             number: 4,
-            title: "Bilateral Coordination",
-            description: "Switch between left and right arm motor imagery. Each bubble is assigned to a specific arm.",
+            title: "Precision Control",
+            description: "Higher target density in full 3D space. Sustained focus and accuracy under load.",
             duration: 120,
             bubbleCount: 10,
             bubbleRadius: 0.06,
             allowedAxes: .xyz,
-            armMode: .bilateral,
             bubbleSpeed: 0...0,
             bubbleLifetime: nil,
             respawnsEnabled: false,
@@ -149,12 +135,11 @@ extension StageConfig {
         StageConfig(
             number: 5,
             title: "Dynamic Flow",
-            description: "Pop moving targets before they disappear. Both arms, full 3D, under time pressure.",
+            description: "Pop moving targets before they disappear. Full 3D, under time pressure.",
             duration: 120,
             bubbleCount: 6,
             bubbleRadius: 0.06,
             allowedAxes: .xyz,
-            armMode: .bilateral,
             bubbleSpeed: 0.02...0.05,
             bubbleLifetime: 12.0,
             respawnsEnabled: true,


### PR DESCRIPTION
Drop the per-bubble assigned-arm gating that powered the old Bilateral Coordination stage:

- StageConfig: delete the ArmMode enum, the armMode field, the isBilateral helper, and the armMode: argument from every stage. Stage 4 is renamed from "Bilateral Coordination" to "Precision Control" (higher target density in full 3-D space) and Stage 5 description no longer mentions "Both arms".
- Bubble: remove the assignedArm field, its initializer parameter, the canBePopped(by:) gate, and the Equatable comparison line.
- BubbleGameController: drop every canBePopped(by:) guard in pop and targeting paths so any active arm can pop any visible bubble. The switch on config.armMode in generateBubbles is gone — colour is simply random per spawn. eyeTargetText now reports the bubble's colour instead of the assigned arm.